### PR TITLE
Use .ruby-version for Gemfile ruby version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-ruby "2.5.3" 
+ruby File.open('.ruby-version', &:readline).delete "ruby-"
 
 gem "fastlane", "~> 2.109"


### PR DESCRIPTION
Resolves the `.ruby-version` part of #20