### PR TITLE
Simplify presentations.

### DIFF
--- a/Application/Source/Detail/View/DetailPresenter.swift
+++ b/Application/Source/Detail/View/DetailPresenter.swift
@@ -16,25 +16,23 @@ extension DetailPresentingViewModel {
     /// - Parameter setupViewModel: This closure will be called with the presenting view model when a present action
     ///             is executed. Consumers can use this to observe changes to the presenting view model if necessary.
     func makePresentDetail(setupViewModel: ((DetailViewModel) -> Void)? = nil) -> Action<Bool, DetailViewModel, NoError> {
-        return makePresent(
-            getPresenter: { [weak self] in
-                return self?.detailPresenter
-            },
-            getViewModel: { (presenter) in
-                let viewModel = presenter.makeDetailViewModel()
+        return makePresentAction { [weak self] animated -> DismissablePresentationContext<DetailViewModel>? in
+            guard
+                let self = self,
+                let presenter = self.detailPresenter else {
+                    return nil
+            }
 
-                viewModel.selectionPresenter = presenter
+            let viewModel = presenter.makeDetailViewModel()
 
-                setupViewModel?(viewModel)
+            viewModel.selectionPresenter = presenter
 
-                return viewModel
-            },
-            getPresentation: { (presenter, viewModel) in
-                return presenter.detailPresentation(of: viewModel)
-            },
-            getContext: { (presentation, _, animated) in
-                return DismissablePresentationContext(presentation: presentation, presentAnimated: animated)
-            })
+            setupViewModel?(viewModel)
+
+            let presentation = presenter.detailPresentation(of: viewModel)
+
+            return DismissablePresentationContext(presentation: presentation, viewModel: viewModel, presentAnimated: animated)
+        }
     }
 
 }

--- a/Application/Source/Home/View/HomeViewPresenter.swift
+++ b/Application/Source/Home/View/HomeViewPresenter.swift
@@ -16,25 +16,23 @@ extension HomePresentingViewModel {
     /// - Parameter setupViewModel: This closure will be called with the presenting view model when a present action
     ///             is executed. Consumers can use this to observe changes to the presenting view model if necessary.
     func makePresentHome(setupViewModel: ((HomeViewModel) -> Void)? = nil) -> Action<Bool, HomeViewModel, NoError> {
-        return makePresent(
-            getPresenter: { [weak self] in
-                return self?.homePresenter
-            },
-            getViewModel: { (presenter) in
-                let viewModel = presenter.makeHomeViewModel()
+        return makePresentAction { [weak self] animated -> DismissablePresentationContext<HomeViewModel>? in
+            guard
+                let self = self,
+                let presenter = self.homePresenter else {
+                    return nil
+            }
 
-                viewModel.detailPresenter = presenter
+            let viewModel = presenter.makeHomeViewModel()
 
-                setupViewModel?(viewModel)
+            viewModel.detailPresenter = presenter
 
-                return viewModel
-            },
-            getPresentation: { (presenter, viewModel) in
-                return presenter.homePresentation(of: viewModel)
-            },
-            getContext: { (presentation, _, animated) in
-                return DismissablePresentationContext(presentation: presentation, presentAnimated: animated)
-            })
+            setupViewModel?(viewModel)
+
+            let presentation = presenter.homePresentation(of: viewModel)
+
+            return DismissablePresentationContext(presentation: presentation, viewModel: viewModel, presentAnimated: animated)
+        }
     }
 
 }

--- a/Application/Source/Selection/SelectionPresenter.swift
+++ b/Application/Source/Selection/SelectionPresenter.swift
@@ -14,23 +14,21 @@ extension SelectionPresentingViewModel {
     /// - Parameter setupViewModel: This closure will be called with the presenting view model when a present action
     ///             is executed. Consumers can use this to observe changes to the presenting view model if necessary.
     func makePresentSelection(setupViewModel: ((SelectionViewModel) -> Void)? = nil) -> Action<Bool, SelectionViewModel, NoError> {
-        return makePresent(
-            getPresenter: { [weak self] in
-                return self?.selectionPresenter
-            },
-            getViewModel: { (presenter) in
-                let viewModel = presenter.makeSelectionViewModel()
+        return makePresentAction { [weak self] animated -> DismissablePresentationContext<SelectionViewModel>? in
+            guard
+                let self = self,
+                let presenter = self.selectionPresenter else {
+                    return nil
+            }
 
-                setupViewModel?(viewModel)
+            let viewModel = presenter.makeSelectionViewModel()
 
-                return viewModel
-            },
-            getPresentation: { (presenter, viewModel) in
-                return presenter.selectionPresentation(of: viewModel)
-            },
-            getContext: { (presentation, viewModel, animated) in
-                return ResultPresentationContext(presentation: presentation, viewModel: viewModel, presentAnimated: animated)
-            })
+            setupViewModel?(viewModel)
+
+            let presentation = presenter.selectionPresentation(of: viewModel)
+
+            return ResultPresentationContext(presentation: presentation, viewModel: viewModel, presentAnimated: animated)
+        }
     }
 
 }

--- a/Application/Source/Settings/View/SettingsPresenter.swift
+++ b/Application/Source/Settings/View/SettingsPresenter.swift
@@ -14,23 +14,21 @@ extension SettingsPresentingViewModel {
     /// - Parameter setupViewModel: This closure will be called with the presenting view model when a present action
     ///             is executed. Consumers can use this to observe changes to the presenting view model if necessary.
     func makePresentSettings(setupViewModel: ((SettingsViewModel) -> Void)? = nil) -> Action<Bool, SettingsViewModel, NoError> {
-        return makePresent(
-            getPresenter: { [weak self] in
-                return self?.settingsPresenter
-            },
-            getViewModel: { (presenter) in
-                let viewModel = presenter.makeSettingsViewModel()
+        return makePresentAction { [weak self] animated -> DismissablePresentationContext<SettingsViewModel>? in
+            guard
+                let self = self,
+                let presenter = self.settingsPresenter else {
+                    return nil
+            }
 
-                setupViewModel?(viewModel)
+            let viewModel = presenter.makeSettingsViewModel()
 
-                return viewModel
-            },
-            getPresentation: { (presenter, viewModel) in
-                return presenter.settingsPresentation(of: viewModel)
-            },
-            getContext: { (presentation, _, animated) in
-                return DismissablePresentationContext(presentation: presentation, presentAnimated: animated)
-            })
+            setupViewModel?(viewModel)
+
+            let presentation = presenter.settingsPresentation(of: viewModel)
+
+            return DismissablePresentationContext(presentation: presentation, viewModel: viewModel, presentAnimated: animated)
+        }
     }
 
 }

--- a/Presentations/Source/PresentationContext.swift
+++ b/Presentations/Source/PresentationContext.swift
@@ -4,8 +4,10 @@ import Result
 import ReactiveExtensions
 
 public protocol PresentationContext: class {
+    associatedtype ViewModelType: ViewModel
     associatedtype PresentationType: Presentation
     var presentation: PresentationType { get }
+    var viewModel: ViewModelType { get }
     var presentAnimated: Bool { get }
 }
 
@@ -13,15 +15,19 @@ public protocol PresentationContext: class {
 ///
 /// Contains additional information about a presentation in a specific presentation, like whether or not the presentation
 /// and dismissal should be animated.
-public class DismissablePresentationContext: PresentationContext {
+public class DismissablePresentationContext<PresentedViewModel: ViewModel>: PresentationContext {
+
     public typealias PresentationType = DismissablePresentation
+    public typealias ViewModelType = PresentedViewModel
 
     public let presentation: DismissablePresentation
+    public let viewModel: PresentedViewModel
     public let presentAnimated: Bool
     public let dismissAnimated: Bool
 
-    public init(presentation: DismissablePresentation, presentAnimated: Bool = true, dismissAnimated: Bool = true) {
+    public init(presentation: DismissablePresentation, viewModel: PresentedViewModel, presentAnimated: Bool = true, dismissAnimated: Bool = true) {
         self.presentation = presentation
+        self.viewModel = viewModel
         self.presentAnimated = presentAnimated
         self.dismissAnimated = dismissAnimated
     }
@@ -29,14 +35,10 @@ public class DismissablePresentationContext: PresentationContext {
 }
 
 /// A dismissible presentation that dismisses when the provided result view model's result signal sends a value.
-public class ResultPresentationContext<ViewModel: ResultViewModel>: DismissablePresentationContext {
+public class ResultPresentationContext<PresentedViewModel: ResultViewModel>: DismissablePresentationContext<PresentedViewModel> {
 
-    public let viewModel: ViewModel
-
-    public init(presentation: DismissablePresentation, viewModel: ViewModel, presentAnimated: Bool = true, dismissAnimated: Bool = true) {
-        self.viewModel = viewModel
-
-        super.init(presentation: presentation, presentAnimated: presentAnimated, dismissAnimated: dismissAnimated)
+    override public init(presentation: DismissablePresentation, viewModel: PresentedViewModel, presentAnimated: Bool = true, dismissAnimated: Bool = true) {
+        super.init(presentation: presentation, viewModel: viewModel, presentAnimated: presentAnimated, dismissAnimated: dismissAnimated)
 
         let dismiss = presentation.dismiss.apply(dismissAnimated)
             .flatMapError { _ in return SignalProducer<Never, NoError>.empty }

--- a/Presentations/Tests/PresentingViewModelSpec.swift
+++ b/Presentations/Tests/PresentingViewModelSpec.swift
@@ -19,48 +19,7 @@ class PresentatingViewModelSpec: QuickSpec {
 
                         presentingViewModel.presentViewModel.apply(false).start()
 
-                        expect(presentingViewModel.getPresenter.value).to(be(presenter))
-                        expect(presentingViewModel.getViewModel).notTo(beNil())
-
-                        guard let (getViewModelPresenter, getViewModelViewModel) = presentingViewModel.getViewModel.value else {
-                            fail("Failed to get values from getViewModel.")
-                            return
-                        }
-
-                        expect(getViewModelPresenter).to(equal(presenter))
-
-                        guard let (getPresentationPresenter, getPresentationViewModel, getPresentationPresentation) = presentingViewModel.getPresentation.value else {
-                            fail("Failed to get values from getPresentation.")
-                            return
-                        }
-
-                        expect(getPresentationPresenter).to(be(presenter))
-                        expect(getPresentationViewModel).to(be(getViewModelViewModel))
-
-                        guard let (getContextPresentation, getContextViewModel, getContextAnimated) = presentingViewModel.getContext.value else {
-                            fail("Failed to get values from getContext.")
-                            return
-                        }
-
-                        expect(getContextPresentation).to(be(getPresentationPresentation))
-                        expect(getContextViewModel).to(be(getPresentationViewModel))
-                        expect(getContextAnimated).to(be(false))
-                    }
-
-                    it("should propogate the appropriate value for animated") {
-                        let presentingViewModel = StubPresentingViewModel<NSObject>()
-
-                        let presenter = NSObject()
-                        presentingViewModel.presenter = presenter
-
-                        presentingViewModel.presentViewModel.apply(true).start()
-
-                        guard let (_, _, animated) = presentingViewModel.getContext.value else {
-                            fail("Failed to get values from getContext.")
-                            return
-                        }
-
-                        expect(animated).to(be(true))
+                        expect(presentingViewModel.context.value).to(be(false))
                     }
                 }
             }

--- a/Presentations/Tests/Stubs/StubDismissablePresentationContext.swift
+++ b/Presentations/Tests/Stubs/StubDismissablePresentationContext.swift
@@ -3,10 +3,13 @@ import ReactiveSwift
 import Result
 import Presentations
 
-extension DismissablePresentationContext {
+extension DismissablePresentationContext where PresentedViewModel == StubViewModel {
 
-    static func stub(withPresentation presentation: DismissablePresentation = DismissablePresentation.stub()) -> DismissablePresentationContext {
-        return DismissablePresentationContext(presentation: presentation, presentAnimated: false, dismissAnimated: false)
+    static func stub(
+        withPresentation presentation: DismissablePresentation = DismissablePresentation.stub()
+    ) -> DismissablePresentationContext<StubViewModel> {
+        let viewModel = StubViewModel()
+        return DismissablePresentationContext(presentation: presentation, viewModel: viewModel, presentAnimated: false, dismissAnimated: false)
     }
 
 }

--- a/Presentations/Tests/Stubs/StubPresentingViewModel.swift
+++ b/Presentations/Tests/Stubs/StubPresentingViewModel.swift
@@ -8,30 +8,11 @@ class StubPresentingViewModel<Presenter: AnyObject>: PresentingViewModel {
 
     weak var presenter: Presenter?
 
-    let getPresenter = MutableProperty<Presenter?>(nil)
-    let getViewModel = MutableProperty<(Presenter, StubViewModel)?>(nil)
-    let getPresentation = MutableProperty<(Presenter, StubViewModel, DismissablePresentation)?>(nil)
-    let getContext = MutableProperty<(DismissablePresentation, StubViewModel, Bool)?>(nil)
+    let context = MutableProperty<Bool?>(nil)
 
-    private(set) lazy var presentViewModel = makePresent(
-        getPresenter: { [unowned self] () -> Presenter? in
-            let presenter = self.presenter
-            self.getPresenter.value = presenter
-            return presenter
-        },
-        getViewModel: { [unowned self] presenter -> StubViewModel in
-            let viewModel = StubViewModel()
-            self.getViewModel.value = (presenter, viewModel)
-            return viewModel
-        },
-        getPresentation: { [unowned self] (presenter, viewModel) -> DismissablePresentation in
-            let presentation = DismissablePresentation.stub()
-            self.getPresentation.value = (presenter, viewModel, presentation)
-            return presentation
-        },
-        getContext: { [unowned self] (presentation, viewModel, animated) -> DismissablePresentationContext in
-            self.getContext.value = (presentation, viewModel, animated)
-            return DismissablePresentationContext.stub(withPresentation: presentation)
-        })
+    private(set) lazy var presentViewModel = makePresentAction { [unowned self] animated -> DismissablePresentationContext<StubViewModel> in
+        self.context.value = animated
+        return DismissablePresentationContext.stub()
+    }
 
 }


### PR DESCRIPTION
The `makePresent` function on `PresentingViewModel` is renamed to `makePresentAction` and takes a single closure that returns a context, or nil if the context failed to be created.