### PR TITLE
Initialize `SelectionViewModel` with a default value.

### DIFF
--- a/Application/Source/Detail/DetailCoordinator.swift
+++ b/Application/Source/Detail/DetailCoordinator.swift
@@ -44,8 +44,8 @@ extension DetailCoordinator: DetailPresenter {
 
 extension DetailCoordinator: SelectionPresenter {
 
-    func makeSelectionViewModel() -> SelectionViewModel {
-        return factory.viewModel.makeSelectionViewModel()
+    func makeSelectionViewModel(withDefaultValue defaultValue: String?) -> SelectionViewModel {
+        return factory.viewModel.makeSelectionViewModel(withDefaultValue: defaultValue)
     }
 
     func selectionPresentation(of viewModel: SelectionViewModel) -> DismissablePresentation {

--- a/Application/Source/Detail/View/DetailViewModel.swift
+++ b/Application/Source/Detail/View/DetailViewModel.swift
@@ -11,14 +11,21 @@ class DetailViewModel: ViewModel, SelectionPresentingViewModel {
     let title = Property(value: L10n.Detail.title)
 
     /// The value of the result from a selection presentation.
-    let selectionResult = MutableProperty<String?>(nil)
+    var selectionResult: Property<String?> { return Property(capturing: mutableSelectionResult) }
+
     let presentSelectionTitle = Property(value: L10n.Detail.Select.title)
 
-    private(set) lazy var presentSelection = makePresentSelection { [weak self] viewModel in
-        guard let self = self else { fatalError() }
+    private(set) lazy var presentSelection = makePresentSelection(
+        withDefaultValue: { [weak self] in
+            return self?.selectionResult.value
+        },
+        setupViewModel: { [weak self] viewModel in
+            guard let self = self else { fatalError() }
 
-        self.selectionResult <~ viewModel.result
-    }
+            self.mutableSelectionResult <~ viewModel.result
+        })
+
+    private let mutableSelectionResult = MutableProperty<String?>(nil)
 
 }
 

--- a/Application/Source/Home/HomeCoordinator.swift
+++ b/Application/Source/Home/HomeCoordinator.swift
@@ -57,8 +57,8 @@ extension HomeCoordinator: DetailPresenter {
 
 extension HomeCoordinator: SelectionPresenter {
 
-    func makeSelectionViewModel() -> SelectionViewModel {
-        return factory.viewModel.makeSelectionViewModel()
+    func makeSelectionViewModel(withDefaultValue defaultValue: String?) -> SelectionViewModel {
+        return factory.viewModel.makeSelectionViewModel(withDefaultValue: defaultValue)
     }
 
     func selectionPresentation(of viewModel: SelectionViewModel) -> DismissablePresentation {

--- a/Application/Source/Selection/SelectionPresenter.swift
+++ b/Application/Source/Selection/SelectionPresenter.swift
@@ -13,7 +13,10 @@ extension SelectionPresentingViewModel {
     ///
     /// - Parameter setupViewModel: This closure will be called with the presenting view model when a present action
     ///             is executed. Consumers can use this to observe changes to the presenting view model if necessary.
-    func makePresentSelection(setupViewModel: ((SelectionViewModel) -> Void)? = nil) -> Action<Bool, SelectionViewModel, NoError> {
+    func makePresentSelection(
+        withDefaultValue defaultValue: (() -> String?)? = nil,
+        setupViewModel: ((SelectionViewModel) -> Void)? = nil
+    ) -> Action<Bool, SelectionViewModel, NoError> {
         return makePresentAction { [weak self] animated -> DismissablePresentationContext<SelectionViewModel>? in
             guard
                 let self = self,
@@ -21,7 +24,8 @@ extension SelectionPresentingViewModel {
                     return nil
             }
 
-            let viewModel = presenter.makeSelectionViewModel()
+            let value = defaultValue?()
+            let viewModel = presenter.makeSelectionViewModel(withDefaultValue: value)
 
             setupViewModel?(viewModel)
 
@@ -34,6 +38,6 @@ extension SelectionPresentingViewModel {
 }
 
 protocol SelectionPresenter: class {
-    func makeSelectionViewModel() -> SelectionViewModel
+    func makeSelectionViewModel(withDefaultValue defaultValue: String?) -> SelectionViewModel
     func selectionPresentation(of viewModel: SelectionViewModel) -> DismissablePresentation
 }

--- a/Application/Source/Selection/SelectionViewController.swift
+++ b/Application/Source/Selection/SelectionViewController.swift
@@ -33,6 +33,7 @@ class SelectionViewController: UIViewController, ViewController {
         selectionView.submitButton.reactive.title <~ viewModel.submitTitle
         selectionView.submitButton.reactive.pressed = CocoaAction(viewModel.submit)
 
+        selectionView.textField.text = viewModel.input.value
         viewModel.input <~ selectionView.textField.reactive.continuousTextValues
         viewModel.isActive <~ reactive.isAppeared
 

--- a/Application/Source/Selection/SelectionViewModel.swift
+++ b/Application/Source/Selection/SelectionViewModel.swift
@@ -4,11 +4,9 @@ import Presentations
 
 class SelectionViewModel: ResultViewModel {
 
-    typealias Result = String?
-
     let isActive = MutableProperty(false)
 
-    private(set) lazy var result = Signal<Result, NoError> { [weak self] (observer, lifetime) in
+    private(set) lazy var result = Signal<String?, NoError> { [weak self] (observer, lifetime) in
         guard let self = self else { fatalError() }
 
         self.submit.values.producer
@@ -23,13 +21,17 @@ class SelectionViewModel: ResultViewModel {
     /// The value of this property will be sent as a value in the submit action's execution signal.
     ///
     /// This should be bound to the input field.
-    let input = MutableProperty<Result>(nil)
+    let input: MutableProperty<String?>
 
     /// Sends the value of input when executed.
-    private(set) lazy var submit = Action<(), Result, NoError> { [weak self] in
+    private(set) lazy var submit = Action<(), String?, NoError> { [weak self] in
         guard let self = self else { fatalError() }
 
         return SignalProducer(value: self.input.value)
+    }
+
+    init(defaultValue: String?) {
+        input = MutableProperty(defaultValue)
     }
 
 }
@@ -38,8 +40,8 @@ protocol SelectionViewModelFactoryProtocol { }
 
 extension SelectionViewModelFactoryProtocol {
 
-    func makeSelectionViewModel() -> SelectionViewModel {
-        return SelectionViewModel()
+    func makeSelectionViewModel(withDefaultValue defaultValue: String?) -> SelectionViewModel {
+        return SelectionViewModel(defaultValue: defaultValue)
     }
 
 }

--- a/Application/Tests/DetailViewModelSpec.swift
+++ b/Application/Tests/DetailViewModelSpec.swift
@@ -41,6 +41,35 @@ class DetailViewModelSpec: QuickSpec {
 
                     expect(viewModel.selectionResult.value).to(equal(selectionValue))
                 }
+
+                it("should be used to set the default value of the selection view model") {
+                    let presenter = StubSelectionPresenter()
+                    viewModel.selectionPresenter = presenter
+
+                    let value = "Test selection input"
+
+                    presenter.selectionPresentation.signal
+                        .skipNil()
+                        .take(first: 1)
+                        .observeValues { viewModel in
+                            viewModel.input.value = value
+                            viewModel.submit.apply().start()
+                    }
+
+                    viewModel.presentSelection.apply(false).start()
+
+                    var defaultValue: String??
+
+                    presenter.selectionPresentation.signal
+                        .skipNil()
+                        .observeValues { viewModel in
+                            defaultValue = viewModel.input.value
+                    }
+
+                    viewModel.presentSelection.apply(false).start()
+
+                    expect(defaultValue).to(equal(value))
+                }
             }
 
             describe("title") {

--- a/Application/Tests/DetailViewModelSpec.swift
+++ b/Application/Tests/DetailViewModelSpec.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable function_body_length
+
 import Quick
 import Nimble
 import ReactiveSwift
@@ -81,3 +83,5 @@ class DetailViewModelSpec: QuickSpec {
 
     }
 }
+
+// swiftlint:enable function_body_length

--- a/Application/Tests/SelectionViewModelSpec.swift
+++ b/Application/Tests/SelectionViewModelSpec.swift
@@ -8,10 +8,12 @@ import Result
 class SelectionViewModelSpec: QuickSpec {
     override func spec() {
 
+        let defaultValue = "Test default value"
+
         var viewModel: SelectionViewModel!
 
         beforeEach {
-            viewModel = SelectionViewModel()
+            viewModel = SelectionViewModel(defaultValue: defaultValue)
         }
 
         describe("SelectionViewModel") {
@@ -20,8 +22,8 @@ class SelectionViewModelSpec: QuickSpec {
             }
 
             describe("input") {
-                it("should initialize as nil") {
-                    expect(viewModel.input.value).to(beNil())
+                it("should initialize as the default value") {
+                    expect(viewModel.input.value).to(equal(defaultValue))
                 }
             }
 
@@ -34,6 +36,9 @@ class SelectionViewModelSpec: QuickSpec {
             describe("submit") {
                 context("when input is nil") {
                     it("should send the value") {
+                        let newValue = "New test value"
+                        viewModel.input.value = newValue
+
                         var submitValue: String??
                         viewModel.submit.apply()
                             .on(value: { value in
@@ -46,7 +51,7 @@ class SelectionViewModelSpec: QuickSpec {
                             return
                         }
 
-                        expect(sentValue).to(beNil())
+                        expect(sentValue).to(equal(newValue))
                     }
                 }
 

--- a/Application/Tests/Stubs/StubSelectionPresenter.swift
+++ b/Application/Tests/Stubs/StubSelectionPresenter.swift
@@ -13,8 +13,8 @@ class StubSelectionPresenter {
 
 extension StubSelectionPresenter: SelectionPresenter {
 
-    func makeSelectionViewModel() -> SelectionViewModel {
-        let viewModel = SelectionViewModel()
+    func makeSelectionViewModel(withDefaultValue defaultValue: String?) -> SelectionViewModel {
+        let viewModel = SelectionViewModel(defaultValue: defaultValue)
         makeSelectionViewModelCall.value = viewModel
         return viewModel
     }

--- a/Presentations/Source/PresentingViewModel.swift
+++ b/Presentations/Source/PresentingViewModel.swift
@@ -14,12 +14,12 @@ public extension PresentingViewModel {
     ///
     /// - Parameter context: A closure that returns a presentation context or nil if the context failed to be created.
     ///             If nil is returned, this action will have no effect.
-    public func makePresentAction<PresentationContextType: PresentationContext>(
-        withContext context: @escaping (_ animated: Bool) -> PresentationContextType?
-    ) -> Action<Bool, PresentationContextType.ViewModelType, NoError> {
-        return Action<Bool, PresentationContextType.ViewModelType, NoError> { (animated: Bool) in
+    public func makePresentAction<Input, PresentationContextType: PresentationContext>(
+        withContext context: @escaping (Input) -> PresentationContextType?
+    ) -> Action<Input, PresentationContextType.ViewModelType, NoError> {
+        return Action<Input, PresentationContextType.ViewModelType, NoError> { input in
             return SignalProducer<PresentationContextType.ViewModelType, NoError> { (observer, lifetime) in
-                guard let context = context(animated) else {
+                guard let context = context(input) else {
                     observer.sendCompleted()
                     return
                 }

--- a/Presentations/Tests/Stubs/StubPresentingViewModel.swift
+++ b/Presentations/Tests/Stubs/StubPresentingViewModel.swift
@@ -10,9 +10,9 @@ class StubPresentingViewModel<Presenter: AnyObject>: PresentingViewModel {
 
     let context = MutableProperty<Bool?>(nil)
 
-    private(set) lazy var presentViewModel = makePresentAction { [unowned self] animated -> DismissablePresentationContext<StubViewModel> in
-        self.context.value = animated
-        return DismissablePresentationContext.stub()
-    }
+    private(set) lazy var presentViewModel: Action<Bool, StubViewModel, NoError> = makePresentAction { [unowned self] animated -> DismissablePresentationContext<StubViewModel> in
+            self.context.value = animated
+            return DismissablePresentationContext.stub()
+        }
 
 }


### PR DESCRIPTION
Additionally:
- Gives the `makePresentationAction` command the ability to specify its input parameter type
- Makes `DetailViewModel`’s `selectionResult` readonly (`Property` instead of `MutableProperty`).