### PR TITLE
Add content title and button to Details view

### DIFF
--- a/Application/Source/Detail/View/DetailPresenter.swift
+++ b/Application/Source/Detail/View/DetailPresenter.swift
@@ -14,8 +14,8 @@ extension DetailPresentingViewModel {
     /// This action should be executed with a Bool indicating whether the presentation should be animated.
     ///
     /// - Parameter factory: A factory to be used to generate the presented view model.
-    /// - Parameter setupViewModel: This closure will be called with the presenting view model when a present action
-    ///             is executed. Consumers can use this to observe changes to the presenting view model if necessary.
+    /// - Parameter setupViewModel: This closure will be called with the presented view model when a present action
+    ///             is executed. Consumers can use this to observe changes to the presented view model if necessary.
     func makePresentDetail(
         withFactory factory: DetailViewModelFactoryProtocol,
         setupViewModel: ((DetailViewModel) -> Void)? = nil

--- a/Application/Source/Detail/View/DetailView.swift
+++ b/Application/Source/Detail/View/DetailView.swift
@@ -23,11 +23,26 @@ class DetailView: UIView {
         return label
     }()
 
+    let contentsListTitle: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    let contentsButton: UIButton = {
+        let button = UIButton()
+        button.setTitleColor(.blue, for: .normal)
+        return button
+    }()
+
     private(set) lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
             title,
             button,
             selectionResult,
+            contentsListTitle,
+            contentsButton
         ])
         stackView.axis = .vertical
         stackView.alignment = .center

--- a/Application/Source/Detail/View/DetailViewController.swift
+++ b/Application/Source/Detail/View/DetailViewController.swift
@@ -38,8 +38,15 @@ class DetailViewController: UIViewController, ViewController {
         viewModel.selectionResult
             .bind(to: detailView.selectionResult.rx.text)
             .disposed(by: disposeBag)
+        viewModel.contentsListTitle
+            .bind(to: detailView.contentsListTitle.rx.text)
+            .disposed(by: disposeBag)
+        viewModel.contentsButtonTitle
+            .bind(to: detailView.contentsButton.rx.title())
+            .disposed(by: disposeBag)
 
         detailView.button.rx.bind(to: viewModel.presentSelection, input: true)
+        detailView.contentsButton.rx.bind(to: viewModel.presentContents, input: ())
 
         rx.isAppeared
             .bind(to: viewModel.isActive)

--- a/Application/Source/Detail/View/DetailViewControllerStyle.swift
+++ b/Application/Source/Detail/View/DetailViewControllerStyle.swift
@@ -22,8 +22,10 @@ struct DetailViewControllerStyle: Style {
 
         background.apply(to: view)
         title.apply(to: view.title)
+        title.apply(to: view.contentsListTitle)
         selectionResult.apply(to: view.selectionResult)
         button.apply(to: view.button)
+        button.apply(to: view.contentsButton)
 
         view.stackView.spacing = theme.layout.interitemSpacing
     }

--- a/Application/Source/Detail/View/DetailViewModel.swift
+++ b/Application/Source/Detail/View/DetailViewModel.swift
@@ -2,6 +2,7 @@ import RxSwift
 import RxCocoa
 import RxExtensions
 import Presentations
+import Action
 
 class DetailViewModel: ViewModel, SelectionPresentingViewModel {
 
@@ -15,6 +16,14 @@ class DetailViewModel: ViewModel, SelectionPresentingViewModel {
     var selectionResult: Property<String?> { return selectionResultRelay.asProperty() }
 
     let presentSelectionTitle = Property(L10n.Detail.Select.title)
+
+    let contentsListTitle = Property(L10n.Detail.ContentsList.title)
+    let contentsButtonTitle = Property(L10n.Detail.ContentsButton.title)
+
+    let presentContents = CocoaAction { _ in
+        print("Content button pressed")
+        return .empty()
+    }
 
     private(set) lazy var presentSelection = makePresentSelection(
         withFactory: selectionFactory,

--- a/Application/Source/Home/View/HomeViewModel.swift
+++ b/Application/Source/Home/View/HomeViewModel.swift
@@ -24,7 +24,7 @@ class HomeViewModel: ViewModel, DetailPresentingViewModel {
 
         let testTextInternalObserver = Observable<UInt>
             // Add a delay to simulate a network operation.
-            .timer(RxTimeInterval(0.5), scheduler: backgroundScheduler)
+            .timer(RxTimeInterval(1.0), scheduler: backgroundScheduler)
             .take(1)
             .map { _ -> String? in
                 return L10n.Home.testText

--- a/Application/Source/Home/View/HomeViewPresenter.swift
+++ b/Application/Source/Home/View/HomeViewPresenter.swift
@@ -14,8 +14,8 @@ extension HomePresentingViewModel {
     /// This action should be executed with a Bool indicating whether the presentation should be animated.
     ///
     /// - Parameter factory: A factory to be used to generate the presented view model.
-    /// - Parameter setupViewModel: This closure will be called with the presenting view model when a present action
-    ///             is executed. Consumers can use this to observe changes to the presenting view model if necessary.
+    /// - Parameter setupViewModel: This closure will be called with the presented view model when a present action
+    ///             is executed. Consumers can use this to observe changes to the presented view model if necessary.
     func makePresentHome(
         withFactory factory: HomeViewModelFactoryProtocol,
         setupViewModel: ((HomeViewModel) -> Void)? = nil

--- a/Application/Source/Selection/SelectionPresenter.swift
+++ b/Application/Source/Selection/SelectionPresenter.swift
@@ -13,8 +13,8 @@ extension SelectionPresentingViewModel {
     ///
     /// - Parameter factory: A factory to be used to generate the presented view model.
     /// - Parameter defaultValue: A closure that provides the default value of the selection input.
-    /// - Parameter setupViewModel: This closure will be called with the presenting view model when a present action
-    ///             is executed. Consumers can use this to observe changes to the presenting view model if necessary.
+    /// - Parameter setupViewModel: This closure will be called with the presented view model when a present action
+    ///             is executed. Consumers can use this to observe changes to the presented view model if necessary.
     func makePresentSelection(
         withFactory factory: SelectionViewModelFactoryProtocol,
         defaultValue: (() -> String?)? = nil,

--- a/Application/Source/Settings/View/SettingsPresenter.swift
+++ b/Application/Source/Settings/View/SettingsPresenter.swift
@@ -12,8 +12,8 @@ extension SettingsPresentingViewModel {
     /// Makes an action that is suitable to be set as the presentSettings action.
     ///
     /// - Parameter factory: A factory to be used to generate the presented view model.
-    /// - Parameter setupViewModel: This closure will be called with the presenting view model when a present action
-    ///             is executed. Consumers can use this to observe changes to the presenting view model if necessary.
+    /// - Parameter setupViewModel: This closure will be called with the presented view model when a present action
+    ///             is executed. Consumers can use this to observe changes to the presented view model if necessary.
     func makePresentSettings(
         withFactory factory: SettingsViewModelFactoryProtocol,
         setupViewModel: ((SettingsViewModel) -> Void)? = nil

--- a/Application/Source/SwiftGen/Strings.swift
+++ b/Application/Source/SwiftGen/Strings.swift
@@ -15,6 +15,14 @@ internal enum L10n {
   internal enum Detail {
     /// Details
     internal static let title = L10n.tr("Localizable", "detail.title")
+    internal enum ContentsButton {
+      /// Contents Info
+      internal static let title = L10n.tr("Localizable", "detail.contents_button.title")
+    }
+    internal enum ContentsList {
+      /// Contents
+      internal static let title = L10n.tr("Localizable", "detail.contents_list.title")
+    }
     internal enum Select {
       /// Select Text
       internal static let title = L10n.tr("Localizable", "detail.select.title")

--- a/Application/Supporting Files/Base.lproj/Localizable.strings
+++ b/Application/Supporting Files/Base.lproj/Localizable.strings
@@ -7,6 +7,12 @@
 /* The title of the tab bar item for the detail navigation flow. */
 "detail_navigation.tab_bar_item.title" = "Detail";
 
+/* Title for the contents list on the details view. */
+"detail.contents_list.title" = "Contents";
+
+/* Title for the contents button that presents the contents view. */
+"detail.contents_button.title" = "Contents Info";
+
 /* The title of the button that presents the detail view. */
 "home.present_detail.title" = "Details";
 

--- a/Application/Tests/HomeViewModelSpec.swift
+++ b/Application/Tests/HomeViewModelSpec.swift
@@ -26,7 +26,7 @@ class HomeViewModelSpec: QuickSpec {
 
                         viewModel.isActive.accept(true)
 
-                        expect(viewModel.testText.value).toEventually(equal(L10n.Home.testText))
+                        expect(viewModel.testText.value).toEventually(equal(L10n.Home.testText), timeout: 2.0)
                     }
                 }
             }

--- a/Core/Source/Themes/Themes.swift
+++ b/Core/Source/Themes/Themes.swift
@@ -34,7 +34,7 @@ public extension Theme {
 
     public var layout: Layout {
         return Layout(
-            interitemSpacing: 10,
+            interitemSpacing: 20,
             buttonContentEdgeInsets: UIEdgeInsets(top: 8, left: 20, bottom: 8, right: 20),
             buttonBorderWidth: 1,
             buttonCornerRadius: 12,


### PR DESCRIPTION
![screen shot 2019-01-16 at 1 42 49 am](https://user-images.githubusercontent.com/2940471/51240264-38962780-1930-11e9-8b60-08dd29f3b1fd.png)

This is an incremental PR to add a new title and button to the details view.
Will eventually lead to a ContentsTableViewController.

Also included some small updates that seemed apt to me (happy to revert if not).

Note- this is going into a feature branch, and not `master`.